### PR TITLE
granite::orm -> granite

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,3 +7,8 @@ authors:
 crystal: 0.23.1
 
 license: MIT
+
+dependencies:
+  redis:
+    github: stefanwille/crystal-redis
+    version: ~> 1.9.0

--- a/src/external_classes.cr
+++ b/src/external_classes.cr
@@ -1,0 +1,1 @@
+class Granite::Base; end

--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -1,3 +1,4 @@
+require "./external_classes"
 require "./mosquito/*"
 
 module Mosquito

--- a/src/mosquito/base.cr
+++ b/src/mosquito/base.cr
@@ -1,5 +1,5 @@
 module Mosquito
-  alias Model = Granite::ORM::Base
+  alias Model = Granite::Base
   alias Id = Int64 | Int32
 
   class Base


### PR DESCRIPTION
Renames granite to match the latest naming on the granite project.