### PR TITLE
Custom serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ This repository uses [minitest](https://github.com/ysbaddaden/minitest.cr) for t
 make test
 ```
 
+In lieu of `crystal spec` bells and whistles, Minitest provides a nice alternative to [running one test at a time instead of the whole suite](https://github.com/ysbaddaden/minitest.cr/pull/31).
+
 ## Contributors
 
 - [robacarp](https://github.com/robacarp) robacarp - creator, maintainer

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -9,7 +9,7 @@ module Mosquito
   # - Jobs Rescue when a #perform method fails a task for any reason
   # - Jobs can be rescheduleable
   abstract class Job
-    include Mosquito::Serializers
+    include Mosquito::Serializers::Primitives
 
     def log(message)
       Base.log "[#{self.class.name}-#{task_id}] #{message}"

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "./serializers/*"
 
 module Mosquito
   # A Job is a definition for work to be performed.
@@ -8,6 +9,8 @@ module Mosquito
   # - Jobs Rescue when a #perform method fails a task for any reason
   # - Jobs can be rescheduleable
   abstract class Job
+    include Mosquito::Serializers
+
     def log(message)
       Base.log "[#{self.class.name}-#{task_id}] #{message}"
     end

--- a/src/mosquito/queued_job.cr
+++ b/src/mosquito/queued_job.cr
@@ -66,7 +66,12 @@ module Mosquito
                   if %object = {{ parameter["name"] }}?
                       %object
                   else
-                    raise "Expected a parameter named {{ parameter["name"] }} but found nil instead. The record may not exist in the database or the parameter may not have been provided when the job was enqueued."
+                    msg = <<-MSG
+                      Expected a parameter named {{ parameter["name"] }} but found nil.
+                      Should you be using `#{{ parameter["name"] }}?` instead?
+                      The record may not exist in the database or the parameter may not have been provided when the job was enqueued1
+                    MSG
+                    raise msg
                   end
                 end
 

--- a/src/mosquito/queued_job.cr
+++ b/src/mosquito/queued_job.cr
@@ -95,17 +95,7 @@ module Mosquito
 
           def vars_from(config : Hash(String, String))
             {% for parameter in parsed_parameters %}
-               {% if parameter["simplified_type"] < Mosquito::Model %}
-
-                  if %model_id = config["{{ parameter["name"] }}_id"]?
-                    @{{ parameter["name"] }} = {{ parameter["simplified_type"] }}.find( %model_id.to_i )
-                  end
-
-               {% elsif parameter["simplified_type"] == String %}
-
-                  @{{ parameter["name"] }} = config["{{ parameter["name"] }}"]?
-
-               {% end %}
+              @{{ parameter["name"] }} = deserialize_{{ parameter["simplified_type"].stringify.underscore.id }}(config["{{ parameter["name"] }}"])
             {% end %}
           end
 
@@ -113,21 +103,11 @@ module Mosquito
             task = Mosquito::Task.new(job_name)
 
             {% for parameter in parsed_parameters %}
-               {% if parameter["simplified_type"] < Mosquito::Model %}
-                  if %model = {{ parameter["name"] }}
-                    task.config["{{ parameter["name"] }}_id"] = %model.id.to_s
-                  end
-               {% elsif parameter["simplified_type"] < Mosquito::Id %}
-                  task.config["{{ parameter["name"] }}"] = {{ parameter["name"] }}.to_s
-               {% elsif parameter["simplified_type"] < String || parameter["simplified_type"] == String %}
-                  task.config["{{ parameter["name"] }}"] = {{ parameter["name"] }}
-               {% end %}
+              task.config["{{ parameter["name"] }}"] = serialize_{{ parameter["simplified_type"].stringify.underscore.id }}({{ parameter["name"] }})
             {% end %}
 
             task
           end
-
-        {% debug() %}
         {% end %}
       end
     end

--- a/src/mosquito/serializers/granite.cr
+++ b/src/mosquito/serializers/granite.cr
@@ -4,7 +4,7 @@ module Mosquito::Serializers::Granite
       model.id.to_s
     end
 
-    def deserialize_{{ klass.stringify.underscore.id }}(raw : String) : {{ klass.id }}
+    def deserialize_{{ klass.stringify.underscore.id }}(raw : String) : {{ klass.id }}?
       id = raw.to_i
       {{ klass.id }}.find id
     end

--- a/src/mosquito/serializers/granite.cr
+++ b/src/mosquito/serializers/granite.cr
@@ -1,0 +1,12 @@
+module Mosquito::Serializers::Granite
+  macro serialize_granite_model(klass)
+    def serialize_{{ klass.stringify.underscore.id }}(model : {{ klass.id }}) : String
+      model.id.to_s
+    end
+
+    def deserialize_{{ klass.stringify.underscore.id }}(raw : String) : {{ klass.id }}
+      id = raw.to_i
+      {{ klass.id }}.find id
+    end
+  end
+end

--- a/src/mosquito/serializers/primitives.cr
+++ b/src/mosquito/serializers/primitives.cr
@@ -1,4 +1,4 @@
-module Mosquito::Serializers
+module Mosquito::Serializers::Primitives
   def serialize_string(str : String) : String
     str
   end

--- a/src/mosquito/serializers/primitives.cr
+++ b/src/mosquito/serializers/primitives.cr
@@ -1,0 +1,70 @@
+module Mosquito::Serializers
+  def serialize_string(str : String) : String
+    str
+  end
+
+  def deserialize_string(raw : String) : String?
+    raw
+  end
+
+  def serialize_bool(value : Bool) : String
+    value.to_s
+  end
+
+  def deserialize_bool(raw : String) : Bool
+    raw == "true"
+  end
+
+  def serialize_symbol(sym : Symbol) : Nil
+    raise "Symbols cannot be deserialized. Stringify your symbol first to pass it as a mosquito job parameter."
+  end
+
+  def serialize_char(char : Char) : String
+    char.to_s
+  end
+
+  def deserialize_char(raw : String) : Char
+    raw[0]
+  end
+
+  {% begin %}
+    {%
+       primitives = [
+         { Int8, :to_i8 },
+         { Int16, :to_i16 },
+         { Int32, :to_i32 },
+         { Int64, :to_i64 },
+         { Int128, :to_i128 },
+
+         { UInt8, :to_u8 },
+         { UInt16, :to_u16 },
+         { UInt32, :to_u32 },
+         { UInt64, :to_u64 },
+         { UInt128, :to_u128 },
+
+         { Float32, :to_f32 },
+         { Float64, :to_f64 }
+       ]
+
+     %}
+     {% for mapping in primitives %}
+
+        {%
+          type = mapping.first
+          method_suffix = type.stringify.underscore
+          method = mapping.last
+        %}
+
+        def serialize_{{ method_suffix.id }}(value) : String
+          value.to_s
+        end
+
+        def deserialize_{{ method_suffix.id }}(raw : String) : {{ type.id }}?
+          if raw
+            raw.{{ method.id }}
+          end
+        end
+
+    {% end %}
+  {% end %}
+end

--- a/test/mosquito/periodic_job_test.cr
+++ b/test/mosquito/periodic_job_test.cr
@@ -2,18 +2,22 @@ require "../test_helper"
 
 describe Mosquito::PeriodicJob do
   it "correctly renders job_type" do
-    skip
+    assert_equal "mosquito::test_jobs::periodic", TestJobs::Periodic.job_type
   end
 
   it "builds a task" do
-    skip
+    job = TestJobs::Periodic.new
+    task = job.build_task
+
+    assert_instance_of Task, task
+    assert_equal TestJobs::Periodic.job_type, task.type
   end
 
   it "is not reschedulable" do
-    skip
+    refute TestJobs::Periodic.new.rescheduleable?
   end
 
   it "registers in job mapping" do
-    skip
+    assert_equal TestJobs::Periodic, Base.job_for_type(TestJobs::Periodic.job_type)
   end
 end

--- a/test/mosquito/periodic_job_test.cr
+++ b/test/mosquito/periodic_job_test.cr
@@ -1,0 +1,19 @@
+require "../test_helper"
+
+describe Mosquito::PeriodicJob do
+  it "correctly renders job_type" do
+    skip
+  end
+
+  it "builds a task" do
+    skip
+  end
+
+  it "is not reschedulable" do
+    skip
+  end
+
+  it "registers in job mapping" do
+    skip
+  end
+end

--- a/test/mosquito/periodic_task_test.cr
+++ b/test/mosquito/periodic_task_test.cr
@@ -1,0 +1,7 @@
+require "../test_helper"
+
+describe Mosquito::PeriodicTask do
+  it "tests" do
+    skip
+  end
+end

--- a/test/mosquito/queued_job_test.cr
+++ b/test/mosquito/queued_job_test.cr
@@ -1,0 +1,7 @@
+require "../test_helper"
+
+describe Mosquito::QueuedJob do
+  it "tests" do
+    skip
+  end
+end

--- a/test/mosquito/runner_test.cr
+++ b/test/mosquito/runner_test.cr
@@ -1,0 +1,7 @@
+require "../test_helper"
+
+describe Mosquito::Runner do
+  it "tests" do
+    skip
+  end
+end

--- a/test/mosquito/scheduled_job_test.cr
+++ b/test/mosquito/scheduled_job_test.cr
@@ -1,0 +1,7 @@
+require "../test_helper"
+
+describe Mosquito::ScheduledJob do
+  it "tests" do
+    skip
+  end
+end

--- a/test/mosquito/task_test.cr
+++ b/test/mosquito/task_test.cr
@@ -1,0 +1,7 @@
+require "../test_helper"
+
+describe Mosquito::Task do
+  it "tests" do
+    skip
+  end
+end


### PR DESCRIPTION
This replaces the attempt at a general purpose (de)serializer by case statement with an extensible, customize-able, method based approach.
 
sort of fixes #16

This opens the door for a wider variety of orms and other object storage mechanisms to easily implement serialization, which will make fixing issues like #15 #14 much easier.

Custom serializers (or serializer overrides) are implemented by defining a pair of methods on a job called `serialize_<type>`. For example, the methods which handle Int32 are:

```crystal
def serialize_int32(value : Int32) : String
  value.to_s
end

def deserialize_int32(raw : String) : Int32?
  if raw
    raw.to_i32
  end
end
```

These methods are declared in the abstract Job class, which means that they're override-able too, to your hearts content:

```crystal
class PutsJob < Mosquito::QueuedJob
   params(count : Int32 | Nil)

  def perform
    count.times { puts "puts job" }
  end

  def deserialize_int32(raw : String) : Int32
    puts "custom deserialization, with a default value!"
    if raw
      raw.to_i32
    else
      0
    end
  end
end
```

Serializing ORM models gets a little more complicated, but I think this will be a better abstraction. To match the current functionality, I'm including a Serializers::Granite module, which provides a macro to generate serializers for model classes. It's used like this:

```crystal
class PutsJob < Mosquito::QueuedJob
  include Mosquito::Serializers::Granite

  params(user : User | Nil)

  serialize_granite_model User

  def perform
    puts "Hello user #{user.id}"
  end
end
```

`serialize_granite_model(User)` generates these methods:

```crystal
def serialize_user(model : User) : String
  model.id.to_s
end

def deserialize_user(raw : String) : User
  id = raw.to_i
  User.find id
end
```

