### PR TITLE
Ability to throttle jobs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Robert L Carpenter
+Copyright (c) 2019 Robert L Carpenter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Mosquito currently provides these features:
 - Automatic rescheduling of failed jobs
 - Progressively increasing delay of failed jobs
 - Dead letter queue of jobs which have failed too many times
+- Rate limited jobs
 
 Current Limitations:
 - Job failure delay, maximum retry count, and several other variables cannot be easily configured.
@@ -120,6 +121,24 @@ Would produce this output:
 ```
 
 More information: [periodic jobs on the wiki](https://github.com/robacarp/mosquito/wiki/Periodic-Jobs)
+
+## Throttling Jobs
+
+Jobs can be throttled to limit the number of messages that get executed within a given period of time.  For example, if 10 messages were enqueued for `ThrottledJob` at one time; 5 would be executed immediately, then pause for a minute, then execute the last 5.  
+
+```crystal
+class ThrottledJob < Mosquito::QueuedJob
+  params message : String
+  throttle limit: 5, period: 60
+
+  def perform
+    puts message
+  end
+end
+```
+
+
+
 
 ## Connecting to Redis
 

--- a/demo/jobs/throttled_job.cr
+++ b/demo/jobs/throttled_job.cr
@@ -1,0 +1,24 @@
+class ThrottledJob < Mosquito::QueuedJob
+  params value : Int32
+
+  throttle limit: 3, period: 10
+
+  def perform
+    log "throttled #{value}"
+
+    # For integration testing
+    Mosquito::Redis.instance.incr self.class.name.underscore
+  end
+end
+
+ThrottledJob.new(1).enqueue
+ThrottledJob.new(2).enqueue
+ThrottledJob.new(3).enqueue
+
+ThrottledJob.new(1).enqueue
+ThrottledJob.new(2).enqueue
+ThrottledJob.new(3).enqueue
+
+ThrottledJob.new(1).enqueue
+ThrottledJob.new(2).enqueue
+ThrottledJob.new(3).enqueue

--- a/demo/run.cr
+++ b/demo/run.cr
@@ -13,16 +13,28 @@ def expect_run_count(klass, expected)
   end
 end
 
+def expect_executed_count(klass, expected)
+  config = Mosquito::Redis.instance.retrieve_hash(klass.queue.config_q)
+  if config["executed"] != expected
+    raise "Expected #{klass.name} to have config.executed == #{expected}.  But got #{config["executed"]}"
+  else
+    puts "#{klass.name} was throttled correctly."
+  end
+end
+
 spawn do
   Mosquito::Runner.start
 end
 
-sleep 10
+sleep 21
 
 puts "End of demo."
 puts "----------------------------------"
 puts "Checking integration test flags..."
 
-expect_run_count(PeriodicallyPuts, 4)
+expect_run_count(PeriodicallyPuts, 7)
 expect_run_count(QueuedJob, 1)
 expect_run_count(CustomSerializersJob, 3)
+
+expect_run_count(ThrottledJob, 9)
+expect_executed_count(ThrottledJob, "0")

--- a/src/mosquito/base.cr
+++ b/src/mosquito/base.cr
@@ -3,8 +3,7 @@ module Mosquito
   alias Id = Int64 | Int32
 
   class Base
-    @@mapping = {} of String => Mosquito::Job.class
-
+    class_getter mapping = {} of String => Mosquito::Job.class
     class_getter scheduled_tasks = [] of PeriodicTask
     class_getter timetable = [] of PeriodicTask
 

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -73,23 +73,23 @@ module Mosquito
     end
 
     # Did the job execute?
-    def executed?
+    def executed? : Bool
       @executed
     end
 
     # Did the job run and succeed?
-    def succeeded?
+    def succeeded? : Bool
       raise "Job hasn't been executed yet" unless @executed
       @succeeded
     end
 
     # Did the job run and fail?
-    def failed?
+    def failed? : Bool
       !succeeded?
     end
 
     # abstract, override if desired.
-    def rescheduleable?
+    def rescheduleable? : Bool
       true
     end
 

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -66,7 +66,7 @@ module Mosquito
       redis.hincrby q, "executed", 1
       config = redis.retrieve_hash q
       return if config["limit"].blank? && config["period"].blank?
-      redis.hset q, "executed", 0 if Time.utc_now.epoch > (Time.epoch(config["last_executed"].to_i64) + config["period"].to_i.seconds).epoch
+      redis.hset q, "executed", 0 if !config["last_executed"].to_i64.zero? && Time.utc_now.epoch > (Time.epoch(config["last_executed"].to_i64) + config["period"].to_i.seconds).epoch
 
       if config["executed"].to_i == config["limit"].to_i
         next_batch = (Time.utc_now + config["period"].to_i.seconds)

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -11,7 +11,7 @@ module Mosquito
   abstract class Job
     include Mosquito::Serializers::Primitives
 
-    class_getter config : Hash(String, String) = {"limit" => "", "period" => "", "executed" => "0", "next_batch" => "0", "last_executed" => "0"}
+    class_getter config : Hash(String, String) = {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"}
 
     def log(message)
       Base.log "[#{self.class.name}-#{task_id}] #{message}"
@@ -99,7 +99,7 @@ module Mosquito
       q = self.class.queue.config_q
       redis.hincrby q, "executed", 1
       config = redis.retrieve_hash q
-      return if config["limit"].blank? && config["period"].blank?
+      return if config["limit"].to_i.zero? && config["period"].to_i.zero?
 
       if config["executed"].to_i == config["limit"].to_i
         next_batch = (Time.utc_now + config["period"].to_i.seconds)

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -11,6 +11,8 @@ module Mosquito
   abstract class Job
     include Mosquito::Serializers::Primitives
 
+    class_getter config : Hash(String, String) = {"limit" => "", "period" => "", "executed" => "0", "next_batch" => "0", "last_executed" => "0"}
+
     def log(message)
       Base.log "[#{self.class.name}-#{task_id}] #{message}"
     end
@@ -19,6 +21,11 @@ module Mosquito
     getter succeeded = false
 
     property task_id : String?
+
+    macro throttle(limit, period)
+      @@config["limit"] = {{limit.stringify}}
+      @@config["period"] = {{period.stringify}}
+    end
 
     def self.job_type : String
       ""
@@ -36,7 +43,6 @@ module Mosquito
       raise DoubleRun.new if executed
       @executed = true
       perform
-      @succeeded = true
     rescue JobFailed
       @succeeded = false
     rescue e : DoubleRun
@@ -48,6 +54,27 @@ module Mosquito
       end
 
       @succeeded = false
+    else
+      increment
+      @succeeded = true
+    end
+
+    # Handles throttling logic
+    def increment : Nil
+      redis = Redis.instance
+      q = self.class.queue.config_q
+      redis.hincrby q, "executed", 1
+      config = redis.retrieve_hash q
+      return if config["limit"].blank? && config["period"].blank?
+      redis.hset q, "executed", 0 if Time.utc_now.epoch > (Time.epoch(config["last_executed"].to_i64) + config["period"].to_i.seconds).epoch
+
+      if config["executed"].to_i == config["limit"].to_i
+        next_batch = (Time.utc_now + config["period"].to_i.seconds)
+        redis.hset q, "executed", 0
+        redis.hset q, "next_batch", next_batch.epoch
+        log "#{"Execution limit reached".colorize.yellow} #{"next_batch".colorize.cyan} in #{config["period"].to_i.seconds} (at #{next_batch})"
+      end
+      redis.hset q, "last_executed", Time.utc_now.epoch
     end
 
     # abstract, override in a Job descendant to do something productive
@@ -76,7 +103,7 @@ module Mosquito
 
     # Did the job run and fail?
     def failed?
-      ! succeeded?
+      !succeeded?
     end
 
     # abstract, override if desired.

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -104,10 +104,10 @@ module Mosquito
       if config["executed"].to_i == config["limit"].to_i
         next_batch = (Time.utc_now + config["period"].to_i.seconds)
         redis.hset q, "executed", 0
-        redis.hset q, "next_batch", next_batch.epoch
+        redis.hset q, "next_batch", next_batch.to_unix
         log "#{"Execution limit reached".colorize.yellow} #{"next_batch".colorize.cyan} in #{config["period"].to_i.seconds} (at #{next_batch})"
       end
-      redis.hset q, "last_executed", Time.utc_now.epoch
+      redis.hset q, "last_executed", Time.utc_now.to_unix
     end
   end
 end

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -99,9 +99,9 @@ module Mosquito
       q = self.class.queue.config_q
       redis.hincrby q, "executed", 1
       config = redis.retrieve_hash q
-      return if config["limit"].to_i.zero? && config["period"].to_i.zero?
+      return if config["limit"] == "0" && config["period"] == "0"
 
-      if config["executed"].to_i == config["limit"].to_i
+      if config["executed"] == config["limit"]
         next_batch = (Time.utc_now + config["period"].to_i.seconds)
         redis.hset q, "executed", 0
         redis.hset q, "next_batch", next_batch.to_unix

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -181,7 +181,7 @@ module Mosquito
       config = get_config
 
       # Return if throttleing is not needed
-      return false if config["limit"].to_i.zero? && config["period"].to_i.zero?
+      return false if config["limit"] == "0" && config["period"] == "0"
 
       # If the last time a job was executed was more than now + period.seconds ago, reset executed back to 0
       # This handles executions not in same time frame
@@ -196,7 +196,7 @@ module Mosquito
       config["next_batch"].to_i64 > Time.utc_now.to_unix
     end
 
-    def get_config : Hash(String, String)
+    private def get_config : Hash(String, String)
       Redis.instance.retrieve_hash config_q
     end
   end

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -186,14 +186,14 @@ module Mosquito
       # If the last time a job was executed was more than now + period.seconds ago, reset executed back to 0
       # This handles executions not in same time frame
       # Which otherwise would cause throttling to kick in once executed == limit even if the executions were hours apart with a 60 sec period
-      if Time.utc_now.epoch > (Time.epoch(config["last_executed"].to_i64) + config["period"].to_i.seconds).epoch
+      if Time.utc_now.to_unix > (Time.unix(config["last_executed"].to_i64) + config["period"].to_i.seconds).to_unix
         config["executed"] = "0"
         Redis.instance.store_hash config_q, config
         return false
       end
 
       # Throttle the job if the next_batch is in the future
-      config["next_batch"].to_i64 > Time.utc_now.epoch
+      config["next_batch"].to_i64 > Time.utc_now.to_unix
     end
 
     def get_config : Hash(String, String)

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -116,6 +116,7 @@ module Mosquito
       q_config = Redis.instance.retrieve_hash config_q
       return if q_config["next_batch"].to_i64 > Time.utc_now.epoch
       if task_id = Redis.instance.rpoplpush waiting_q, pending_q
+        Redis.instance.hset config_q, "executed", 0 if Time.utc_now.epoch > (Time.epoch(q_config["last_executed"].to_i64) + q_config["period"].to_i.seconds).epoch
         Task.retrieve task_id
       else
         @empty = true

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -49,7 +49,7 @@ module Mosquito
       end
     end
 
-    private def set_config
+    private def self.set_config
       redis = Redis.instance
       Base.mapping.each do |k, job|
         redis.store_hash(job.queue.config_q, job.config) if redis.exists(job.queue.config_q).zero?

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -34,6 +34,30 @@ module Mosquito
 
     private def set_start_time
       @start_time = Time.now.to_unix
+
+      Base.log "Mosquito is buzzing..."
+
+      set_config
+
+      loop do
+        start_time
+        fetch_queues
+        enqueue_periodic_tasks
+        enqueue_delayed_tasks
+        dequeue_and_run_tasks
+        idle_wait
+      end
+    end
+
+    private def set_config
+      redis = Redis.instance
+      Base.mapping.each do |k, job|
+        redis.store_hash(job.queue.config_q, job.config) if redis.exists(job.queue.config_q).zero?
+      end
+    end
+
+    private def start_time
+      @start_time = Time.now.epoch
     end
 
     private def idle_wait

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -10,6 +10,8 @@ module Mosquito
       Base.log "Mosquito is buzzing..."
       instance = new
 
+      set_config
+
       while true
         instance.run
       end
@@ -32,32 +34,15 @@ module Mosquito
       idle_wait
     end
 
-    private def set_start_time
-      @start_time = Time.now.to_unix
-
-      Base.log "Mosquito is buzzing..."
-
-      set_config
-
-      loop do
-        start_time
-        fetch_queues
-        enqueue_periodic_tasks
-        enqueue_delayed_tasks
-        dequeue_and_run_tasks
-        idle_wait
-      end
-    end
-
     private def self.set_config
       redis = Redis.instance
       Base.mapping.each do |k, job|
-        redis.store_hash(job.queue.config_q, job.config) if redis.exists(job.queue.config_q).zero?
+        redis.store_hash(job.queue.config_q, job.config)
       end
     end
 
-    private def start_time
-      @start_time = Time.now.epoch
+    private def set_start_time
+      @start_time = Time.now.to_unix
     end
 
     private def idle_wait

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -41,6 +41,18 @@ class PassingJob < Mosquito::QueuedJob
   end
 end
 
+class ThrottledJob < Mosquito::QueuedJob
+  include PerformanceCounter
+  params()
+
+  throttle limit: 5, period: 10
+
+  def perform
+    super
+    true
+  end
+end
+
 class FailingJob < Mosquito::QueuedJob
   include PerformanceCounter
   params()

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -87,7 +87,7 @@ Mosquito::Base.register_job_mapping "failing_job", FailingJob
 def task_config
   {
     "year" => "1752",
-    "name" => "the year september lost 12 days"
+    "name" => "the year september lost 12 days",
   }
 end
 
@@ -95,5 +95,8 @@ def create_task(type = "job_with_config", config = task_config)
   Mosquito::Task.new(type).tap do |task|
     task.config = config
     task.store
+    if job = task.job
+      Mosquito::Redis.instance.store_hash(job.class.queue.config_q, {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"})
+    end
   end
 end

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -21,6 +21,8 @@ describe Mosquito::Job do
   it "run sets #executed? and #succeeded?" do
     refute passing_job.executed?
 
+    Mosquito::Redis.instance.store_hash(passing_job.class.queue.config_q, {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"})
+
     passing_job.run
 
     assert passing_job.executed?
@@ -52,6 +54,7 @@ describe Mosquito::Job do
   end
 
   it "raises DoubleRun if it's already been executed" do
+    Mosquito::Redis.instance.store_hash(passing_job.class.queue.config_q, {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"})
     passing_job.run
     assert_raises Mosquito::DoubleRun do
       passing_job.run

--- a/test/mosquito/queue_test.cr
+++ b/test/mosquito/queue_test.cr
@@ -7,6 +7,7 @@ describe Queue do
   let(:test_queue) do
     Mosquito::Queue.new(name).tap do |queue|
       queue.flush
+      Mosquito::Redis.instance.store_hash(queue.config_q, {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"})
       queue
     end
   end
@@ -25,7 +26,7 @@ describe Queue do
   end
 
   it "builds redis keys for waiting q" do
-    assert_equal "mosquito:queue:#{name}", test_queue.waiting_q
+    assert_equal "mosquito:waiting:#{name}", test_queue.waiting_q
   end
 
   it "builds redis keys for scheduled q" do
@@ -126,8 +127,8 @@ describe "Queue class methods" do
   it "can get a list of available queues" do
     # create evidence of some queues
     redis.flushdb
-    redis.set "mosquito:queue:test1", 1
-    redis.set "mosquito:queue:test2", 1
+    redis.set "mosquito:waiting:test1", 1
+    redis.set "mosquito:waiting:test2", 1
     redis.set "mosquito:scheduled:test3", 1
 
     assert_equal ["test1", "test2", "test3"], Mosquito::Queue.list_queues.sort

--- a/test/mosquito/runner/enqueue_delayed_tasks_test.cr
+++ b/test/mosquito/runner/enqueue_delayed_tasks_test.cr
@@ -5,6 +5,7 @@ describe "Mosquito::Runner#enqueue_delayed_tasks" do
   let(:queue_name) { "mosquito::test_jobs::queued" }
 
   @enqueue_time : Time?
+
   def enqueue_time
     @enqueue_time ||= Time.now
   end
@@ -29,7 +30,7 @@ describe "Mosquito::Runner#enqueue_delayed_tasks" do
         runner.run :enqueue
       end
 
-      queued_tasks = redis.lrange "mosquito:queue:#{queue_name}", 0, -1
+      queued_tasks = redis.lrange "mosquito:waiting:#{queue_name}", 0, -1
       last_task = queued_tasks.last
       task_metadata = redis.retrieve_hash "mosquito:task:#{last_task}"
 
@@ -47,7 +48,7 @@ describe "Mosquito::Runner#enqueue_delayed_tasks" do
         runner.run :enqueue
       end
 
-      queued_tasks = redis.lrange "mosquito:queue:#{queue_name}", 0, -1
+      queued_tasks = redis.lrange "mosquito:waiting:#{queue_name}", 0, -1
       assert_equal 0, queued_tasks.size
     end
   end

--- a/test/mosquito/runner/enqueue_periodic_tasks_test.cr
+++ b/test/mosquito/runner/enqueue_periodic_tasks_test.cr
@@ -13,7 +13,7 @@ describe "Mosquito::Runner#enqueue_periodic_tasks" do
         enqueue_time = Time.now.to_unix_ms
         runner.run :enqueue
 
-        queued_tasks = redis.lrange "mosquito:queue:#{queue_name}", 0, -1
+        queued_tasks = redis.lrange "mosquito:waiting:#{queue_name}", 0, -1
         last_task = queued_tasks.last
         task_metadata = redis.retrieve_hash "mosquito:task:#{last_task}"
 

--- a/test/mosquito/runner/fetch_queues_test.cr
+++ b/test/mosquito/runner/fetch_queues_test.cr
@@ -6,8 +6,8 @@ describe "Mosquito::Runner#fetch_queues" do
 
   it "gets a list of queues from redis" do
     with_fresh_redis do
-      redis.set "mosquito:queue:test1", 1
-      redis.set "mosquito:queue:test2", 1
+      redis.set "mosquito:waiting:test1", 1
+      redis.set "mosquito:waiting:test2", 1
       redis.set "mosquito:scheduled:test3", 1
 
       redis.set "mosquito:not_a_queue:yolo", 23

--- a/test/mosquito/runner/run_tasks_test.cr
+++ b/test/mosquito/runner/run_tasks_test.cr
@@ -10,6 +10,7 @@ describe "Mosquito::Runner#run_next_task" do
 
   def run_task(job)
     job.reset_performance_counter!
+    Mosquito::Redis.instance.store_hash(job.queue.config_q, {"limit" => "0", "period" => "0", "executed" => "0", "next_batch" => "0", "last_executed" => "0"})
     job.new.enqueue
 
     runner.run :fetch_queues
@@ -51,5 +52,4 @@ describe "Mosquito::Runner#run_next_task" do
   it "doesnt reschedule a job that cant be rescheduled" do
     skip
   end
-
 end

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -10,4 +10,5 @@ require "../mosquito"
 require "./helpers/*"
 
 Mosquito::Redis.instance.flushall
+
 require "minitest/autorun"


### PR DESCRIPTION
Resolves #1 

* Ability for arbitrary limits/periods.
* Config hash could be used for other things, like retry amounts etc
* Default is no limit 
* ~Maintains state between starts, would have to delete the old config hash to have it set new values~
* Renames the `WAITING` queue to actually be `waiting`, is more clear.
* Refactors the queue methods into a nice macro :)

~However the more i think about it the one thing this wouldn't solve well is if the tasks get added slowly.  For example you have a job that is set to 10 executions per 60 seconds.  But you add one every 10min.  This implementation would still would wait 60 seconds before executing the 11th task.~

This has been solved, it now only counts executions within the given period seconds.

## How this works:
1. I moved the `@@mapping` class var to a `class_getter` var, as i needed a way to get a list of all defined jobs
2. When starting mosquito it will store a config hash into redis
3. When a task is executed it will increment the `executed` field in the config object
4. If `Time.utc_now.epoch > (Time.epoch(config["last_executed"].to_i64) + config["period"].to_i.seconds).epoch` resets `executed` back to 0
5. When `executed` == `limit`, it will set the `executed` field back to 0 and set the `next_batch` field to `(Time.utc_now + period.seconds).epoch`
6. When going to dequeue a task to run, it checks `q_config["next_batch"].to_i64 > Time.utc_now.epoch` and returns if true

WDYT @robacarp 