### PR TITLE
0.27.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,20 +4,19 @@ version: 0.2.1
 authors:
   - Robert L Carpenter <robert@robacarp.com>
 
-crystal: 0.26.0
+crystal: 0.27.0
 
 license: MIT
 
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.0.0
+    version: ~> 2.1.1
 
 development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
+    version: 0.4.2
 
-    # allows for minitest/focus
-    commit: f68a06356b51803dad5942d99cb2a3e2bdad4880
   timecop:
     github: TobiasGSmollett/timecop.cr

--- a/src/mosquito/periodic_task.cr
+++ b/src/mosquito/periodic_task.cr
@@ -5,7 +5,7 @@ module Mosquito
     property last_executed_at : Time
 
     def initialize(@class, @interval)
-      @last_executed_at = Time.epoch 0
+      @last_executed_at = Time.unix 0
     end
 
     def try_to_execute : Nil

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -77,10 +77,10 @@ module Mosquito
   class Queue
     ID_PREFIX = {"mosquito"}
 
-    WAITING = "queue"
-    PENDING = "pending"
+    WAITING   = "queue"
+    PENDING   = "pending"
     SCHEDULED = "scheduled"
-    DEAD = "dead"
+    DEAD      = "dead"
 
     def self.redis_key(*parts)
       Redis.key ID_PREFIX, parts
@@ -126,7 +126,7 @@ module Mosquito
     end
 
     def enqueue(task : Task, at execute_time : Time)
-      Redis.instance.zadd scheduled_q, execute_time.epoch_ms, task.id
+      Redis.instance.zadd scheduled_q, execute_time.to_unix_ms, task.id
     end
 
     def dequeue
@@ -146,7 +146,7 @@ module Mosquito
 
     def dequeue_scheduled : Array(Task)
       time = Time.now
-      overdue_tasks = Redis.instance.zrangebyscore scheduled_q, 0, time.epoch_ms
+      overdue_tasks = Redis.instance.zrangebyscore scheduled_q, 0, time.to_unix_ms
 
       return [] of Task unless overdue_tasks.any?
 

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -33,11 +33,11 @@ module Mosquito
     end
 
     private def set_start_time
-      @start_time = Time.now.epoch
+      @start_time = Time.now.to_unix
     end
 
     private def idle_wait
-      delta = Time.now.epoch - @start_time
+      delta = Time.now.to_unix - @start_time
       if delta < IDLE_WAIT
         sleep(IDLE_WAIT - delta)
       end
@@ -45,7 +45,7 @@ module Mosquito
 
     private def run_at_most(*, every interval, label name, &block)
       now = Time.now
-      last_execution = @execution_timestamps[name]? || Time.epoch 0
+      last_execution = @execution_timestamps[name]? || Time.unix 0
       delta = now - last_execution
 
       if delta >= interval

--- a/src/mosquito/task.cr
+++ b/src/mosquito/task.cr
@@ -35,7 +35,7 @@ module Mosquito
       @type : String,
       @enqueue_time : Time | Nil,
       @id : String | Nil,
-      @retry_count : Int32,
+      @retry_count : Int32
     )
       @config = {} of String => String
       @job = NilJob.new
@@ -43,7 +43,7 @@ module Mosquito
 
     def store
       @enqueue_time = time = Time.now
-      epoch = time.epoch_ms.to_s
+      epoch = time.to_unix_ms.to_s
 
       unless task_id = @id
         task_id = @id = Redis.key epoch, rand(1000).to_s
@@ -110,7 +110,7 @@ module Mosquito
       return unless timestamp = fields.delete "enqueue_time"
       retry_count = (fields.delete("retry_count") || 0).to_i
 
-      instance = new(name, Time.epoch_ms(timestamp.to_i64), id, retry_count)
+      instance = new(name, Time.unix_ms(timestamp.to_i64), id, retry_count)
       instance.config = fields
 
       instance

--- a/test/mosquito/queue_test.cr
+++ b/test/mosquito/queue_test.cr
@@ -44,7 +44,7 @@ describe Queue do
 
   it "can enqueue a task with a relative time" do
     offset = 3.seconds
-    timestamp = offset.from_now.epoch_ms
+    timestamp = offset.from_now.to_unix_ms
     test_queue.enqueue task, in: offset
     stored_time = redis.zscore test_queue.scheduled_q, task.id
 
@@ -55,7 +55,7 @@ describe Queue do
     timestamp = 3.seconds.from_now
     test_queue.enqueue task, at: timestamp
     stored_time = redis.zscore test_queue.scheduled_q, task.id
-    assert_equal timestamp.epoch_ms, stored_time.not_nil!.to_i64
+    assert_equal timestamp.to_unix_ms, stored_time.not_nil!.to_i64
   end
 
   it "moves a task from waiting to pending on dequeue" do
@@ -96,8 +96,8 @@ describe Queue do
   it "dequeues tasks which have been scheduled for a time that has passed" do
     task1 = task
     task2 = Mosquito::Task.new("mock_task").tap do |task|
-              task.store
-            end
+      task.store
+    end
 
     past = 1.minute.ago
     future = 1.minute.from_now
@@ -130,6 +130,6 @@ describe "Queue class methods" do
     redis.set "mosquito:queue:test2", 1
     redis.set "mosquito:scheduled:test3", 1
 
-    assert_equal ["test1","test2","test3"], Mosquito::Queue.list_queues.sort
+    assert_equal ["test1", "test2", "test3"], Mosquito::Queue.list_queues.sort
   end
 end

--- a/test/mosquito/runner/enqueue_periodic_tasks_test.cr
+++ b/test/mosquito/runner/enqueue_periodic_tasks_test.cr
@@ -10,7 +10,7 @@ describe "Mosquito::Runner#enqueue_periodic_tasks" do
         Mosquito::Base.register_job_mapping queue_name, Mosquito::TestJobs::Periodic
         Mosquito::Base.register_job_interval Mosquito::TestJobs::Periodic, interval: 1.second
 
-        enqueue_time = Time.now.epoch_ms
+        enqueue_time = Time.now.to_unix_ms
         runner.run :enqueue
 
         queued_tasks = redis.lrange "mosquito:queue:#{queue_name}", 0, -1

--- a/test/mosquito/runner/start_time_test.cr
+++ b/test/mosquito/runner/start_time_test.cr
@@ -7,7 +7,7 @@ describe "Mosquito::Runner#set_start_time" do
     Timecop.freeze Time.now do
       assert_equal 0, runner.start_time
       runner.run :start_time
-      assert_equal Time.now.epoch, runner.start_time
+      assert_equal Time.now.to_unix, runner.start_time
     end
   end
 end


### PR DESCRIPTION
This fixes the epoch to unix breaking change.  Also updates deps to the 0.27.0 releases as well.

Running `make test` throw this error tho
```
crystal run test/test_helper.cr test/**/*_test.cr -- --chaos
Module validation failed: !dbg attachment points at wrong subprogram for function
!10 = distinct !DISubprogram(name: "initialize", linkageName: "initialize", scope: !5, file: !5, line: 115, type: !6, isLocal: true, isDefinition: true, scopeLine: 115, isOptimized: false, unit: !0, variables: !2)
void (%"OpenSSL::BIO"*, %TCPSocket*)* @"*OpenSSL::BIO#initialize<TCPSocket>:Nil"
  %2 = call i8** @"~OpenSSL::BIO::CRYSTAL_BIO:read"(), !dbg !12
!12 = !DILocation(line: 14, column: 5, scope: !13)
!13 = distinct !DISubprogram(name: "set_data", linkageName: "set_data", scope: !5, file: !5, line: 13, type: !6, isLocal: true, isDefinition: true, scopeLine: 13, isOptimized: false, unit: !0, variables: !2)
!13 = distinct !DISubprogram(name: "set_data", linkageName: "set_data", scope: !5, file: !5, line: 13, type: !6, isLocal: true, isDefinition: true, scopeLine: 13, isOptimized: false, unit: !0, variables: !2)
 (Exception)
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues
Makefile:7: recipe for target 'test' failed
make: *** [test] Error 1
```

So something is borked in the test portion of code.  However, im not sue what it has to do with yet, maybe @robacarp has an idea?  Anyway, mosquito will at least compile now.