### PR TITLE
Update redis version to support Crystal 0.31.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: crystallang/crystal:0.29.0
-      - image: redis:4.0.9
+      - image: crystallang/crystal:0.31.1
+      - image: redis:4.0.14
     steps:
       - checkout
       - run: shards install

--- a/shard.yml
+++ b/shard.yml
@@ -1,17 +1,17 @@
 name: mosquito
-version: 0.5.0
+version: 0.6.0
 
 authors:
   - robacarp
 
-crystal: 0.29.0
+crystal: 0.31.1
 
 license: MIT
 
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.3.0
+    version: ~> 2.2.0
 
 development_dependencies:
   minitest:

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.1.1
+    version: ~> 2.3.0
 
 development_dependencies:
   minitest:

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ dependencies:
 development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
-    version: ~> 0.4.2
+    version: ~> 0.5.0
 
   timecop:
     github: crystal-community/timecop.cr


### PR DESCRIPTION
This mege request bumps the version number of redis and supports Crystal 0.31.1.