### PR TITLE
update minitest for crystal 0.31.1 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ dependencies:
 development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
-    version: ~> 0.4.2
+    version: ~> 0.5.0
 
   timecop:
     github: crystal-community/timecop.cr


### PR DESCRIPTION
This is the rest of the required compatibility for crystal 0.31.1 with #37.