### PR TITLE
Add a MOSQUITO_REDIS_URL Env Variable by default

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: mosquito
-version: 0.5.0
+version: 0.6.0
 
 authors:
   - robacarp
 
-crystal: 0.29.0
+crystal: 0.31.0
 
 license: MIT
 
@@ -12,6 +12,8 @@ dependencies:
   redis:
     github: stefanwille/crystal-redis
     version: ~> 2.1.1
+  habitat:
+    github: luckyframework/habitat
 
 development_dependencies:
   minitest:

--- a/src/mosquito/base.cr
+++ b/src/mosquito/base.cr
@@ -1,3 +1,5 @@
+require "habitat"
+
 module Mosquito
   alias Model = Granite::Base
   alias Id = Int64 | Int32
@@ -46,5 +48,17 @@ module Mosquito
     def self.log(*messages)
       logger.log(Logger::Severity::INFO, messages.join(" "))
     end
+
+    Habitat.create do
+      setting redis_url : String
+
+      # Optionally add examples to settings that appear in error messages
+      # when the value is not set.
+      #
+      # Use `String#dump` when you want the example to be wrapped in quotes
+      setting redis_url : String, example: "redis://localhost:6379"
+    end
+
+    Habitat.raise_if_missing_settings!
   end
 end

--- a/src/mosquito/queued_job.cr
+++ b/src/mosquito/queued_job.cr
@@ -40,9 +40,9 @@ module Mosquito
                 simplified_type = type.resolve
               end
 
-              method_suffix = simplified_type.stringify.underscore.gsub(/::/,"__").id
+              method_suffix = simplified_type.stringify.underscore.gsub(/::/, "__").id
 
-              { name: name, value: value, type: type, simplified_type: simplified_type, method_suffix: method_suffix }
+              {name: name, value: value, type: type, simplified_type: simplified_type, method_suffix: method_suffix}
             end
           %}
 
@@ -75,13 +75,13 @@ module Mosquito
           end
 
           def initialize({{
-              parsed_parameters.map do |parameter|
-                assignment = "@#{parameter["name"]}"
-                assignment = assignment + " : #{parameter["type"]}" if parameter["type"]
-                assignment = assignment + " = #{parameter["value"]}" if parameter["value"]
-                assignment
-              end.join(", ").id
-              }})
+                           parsed_parameters.map do |parameter|
+                             assignment = "@#{parameter["name"]}"
+                             assignment = assignment + " : #{parameter["type"]}" if parameter["type"]
+                             assignment = assignment + " = #{parameter["value"]}" if parameter["value"]
+                             assignment
+                           end.join(", ").id
+                         }})
           end
 
           def vars_from(config : Hash(String, String))

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -32,7 +32,9 @@ module Mosquito
     end
 
     def initialize
-      if url = ENV["REDIS_URL"]?
+      if url = ENV["MOSQUITO_REDIS_URL"]?
+        @connection = ::Redis.new(url: url)
+      elsif url = ENV["REDIS_URL"]?
         @connection = ::Redis.new(url: url)
       else
         @connection = ::Redis.new

--- a/src/mosquito/serializers/granite.cr
+++ b/src/mosquito/serializers/granite.cr
@@ -1,7 +1,7 @@
 module Mosquito::Serializers::Granite
   macro serialize_granite_model(klass)
     {%
-     method_suffix = klass.stringify.underscore.gsub(/::/,"__").id
+      method_suffix = klass.stringify.underscore.gsub(/::/, "__").id
     %}
     def serialize_{{ method_suffix }}(model : {{ klass.id }}) : String
       model.id.to_s

--- a/src/mosquito/serializers/primitives.cr
+++ b/src/mosquito/serializers/primitives.cr
@@ -29,24 +29,23 @@ module Mosquito::Serializers::Primitives
 
   {% begin %}
     {%
-       primitives = [
-         { Int8, :to_i8 },
-         { Int16, :to_i16 },
-         { Int32, :to_i32 },
-         { Int64, :to_i64 },
-         { Int128, :to_i128 },
+      primitives = [
+        {Int8, :to_i8},
+        {Int16, :to_i16},
+        {Int32, :to_i32},
+        {Int64, :to_i64},
+        {Int128, :to_i128},
 
-         { UInt8, :to_u8 },
-         { UInt16, :to_u16 },
-         { UInt32, :to_u32 },
-         { UInt64, :to_u64 },
-         { UInt128, :to_u128 },
+        {UInt8, :to_u8},
+        {UInt16, :to_u16},
+        {UInt32, :to_u32},
+        {UInt64, :to_u64},
+        {UInt128, :to_u128},
 
-         { Float32, :to_f32 },
-         { Float64, :to_f64 }
-       ]
-
-     %}
+        {Float32, :to_f32},
+        {Float64, :to_f64},
+      ]
+    %}
      {% for mapping in primitives %}
 
         {%

--- a/src/mosquito/version.cr
+++ b/src/mosquito/version.cr
@@ -1,3 +1,3 @@
 module Mosquito
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/test/helpers/bare_base_class.cr
+++ b/test/helpers/bare_base_class.cr
@@ -8,7 +8,6 @@ module Mosquito
       @@mapping = {} of String => Job.class
 
       yield
-
     ensure
       @@mapping = mapping unless mapping.nil?
       @@scheduled_tasks = scheduled_tasks unless scheduled_tasks.nil?
@@ -19,10 +18,8 @@ module Mosquito
       @@logger = Logger.new(STDOUT)
 
       yield
-
     ensure
       @@logger = logger unless logger.nil?
     end
   end
 end
-

--- a/test/mosquito/redis_test.cr
+++ b/test/mosquito/redis_test.cr
@@ -4,7 +4,7 @@ describe Mosquito::Redis do
   let(:data) {
     {
       "question" => "unknown",
-      "answer" => "forty-two"
+      "answer"   => "forty-two",
     }
   }
 

--- a/test/mosquito/runner/run_at_most_test.cr
+++ b/test/mosquito/runner/run_at_most_test.cr
@@ -19,7 +19,7 @@ describe "Mosquito::Runner#run_at_most" do
     count = 0
     moment = Time.utc
     runner
-    incrementy = ->() do
+    incrementy = ->do
       runner.yield_once_a_second do
         count += 1
       end

--- a/test/mosquito/runner_test.cr
+++ b/test/mosquito/runner_test.cr
@@ -1,3 +1,2 @@
 require "../test_helper"
 require "./runner/*"
-

--- a/test/mosquito/task/rescheduling_test.cr
+++ b/test/mosquito/task/rescheduling_test.cr
@@ -9,7 +9,7 @@ describe "task rescheduling" do
       1 => 2,
       2 => 8,
       3 => 18,
-      4 => 32
+      4 => 32,
     }
 
     intervals.each do |count, delay|
@@ -20,7 +20,7 @@ describe "task rescheduling" do
   end
 
   it "prevents rescheduling a job too many times" do
-    run_task = -> do
+    run_task = ->do
       task = Mosquito::Task.retrieve(failing_task.id.not_nil!).not_nil!
       task.run
       task

--- a/test/mosquito/task/storage_test.cr
+++ b/test/mosquito/task/storage_test.cr
@@ -6,7 +6,7 @@ describe "task storage" do
   let(:config) {
     {
       "year" => "1752",
-      "name" => "the year september lost 12 days"
+      "name" => "the year september lost 12 days",
     }
   }
 


### PR DESCRIPTION
The default REDIS_URL might be used by conflicting dependencies, or a app may wish to have a dedicated instance for background jobs. This pull request changes mosquito's behavior to check for a "MOSQUITO_REDIS_URL" ENV Var before using the "REDIS_URL" ENV Var.