### PR TITLE
Properly cleanup task objects in Redis

### DIFF
--- a/src/mosquito/task.cr
+++ b/src/mosquito/task.cr
@@ -57,8 +57,12 @@ module Mosquito
       Redis.instance.store_hash redis_key, fields
     end
 
-    def delete
-      Redis.instance.del redis_key
+    def delete(in ttl = 0)
+      if (ttl > 0)
+        Redis.instance.expire redis_key, ttl
+      else
+        Redis.instance.del redis_key
+      end
     end
 
     def build_job

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -74,6 +74,20 @@ class FailingJob < Mosquito::QueuedJob
   property fail_with_exception = false
 end
 
+class NonReschedulableFailingJob < Mosquito::QueuedJob
+  include PerformanceCounter
+  params()
+
+  def perform
+    super
+    fail
+  end
+
+  def rescheduleable?
+    false
+  end
+end
+
 class NotImplementedJob < Mosquito::Job
 end
 
@@ -95,6 +109,7 @@ end
 Mosquito::Base.register_job_mapping "job_with_config", JobWithConfig
 Mosquito::Base.register_job_mapping "job_with_performance_counter", JobWithPerformanceCounter
 Mosquito::Base.register_job_mapping "failing_job", FailingJob
+Mosquito::Base.register_job_mapping "non_reschedulable_failing_job", FailingJob
 
 def task_config
   {

--- a/test/mosquito/task/storage_test.cr
+++ b/test/mosquito/task/storage_test.cr
@@ -40,4 +40,11 @@ describe "task storage" do
     saved_config = redis.retrieve_hash task.redis_key
     assert_empty saved_config
   end
+
+  it "can set a timed delete on a task" do
+    ttl = 10
+    task.delete(in: ttl)
+    set_ttl = redis.ttl task.redis_key
+    assert_equal ttl, set_ttl
+  end
 end


### PR DESCRIPTION
This provides a configurable interface to keep Mosquito from annihilating your redis memory and disk with runaway storage.

By default:

- Tasks which succeed are given a redis TTL of 1, which means they're cleaned up quickly.
- Tasks which are dead lettered are given a redis TTL of 86400, which means they're cleaned up by redis after a wall-clock day.

This behavior is configurable to a point. The dead letter "heap" is theoretical and is composed of tasks which failed so many times they can't be retried. Increasing the failed_job_ttl allows tasks which won't be re-run for whatever reason to live on _longer_ but the deletion is no longer optional. 

-----------------------

This does not cause Mosquito to clean up jobs which it's already forgotten about. If your dead letter heap has already swallowed your redis instance whole, you'll need to clear it out with `redis-cli flushall` or some other means.

cc @jwaldrip

Fixes #5 
Breaking Change.