### PR TITLE
Allow redis url to be configured without env

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.cr]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,9 @@ dependencies:
   redis:
     github: stefanwille/crystal-redis
     version: ~> 2.6.0
+  habitat:
+    github: luckyframework/habitat
+    version: ~> 0.4.3
 
 development_dependencies:
   minitest:

--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -1,5 +1,10 @@
+require "habitat"
+
 require "./external_classes"
 require "./mosquito/*"
 
 module Mosquito
+  Habitat.create do
+    setting redis_url : String? = ENV["REDIS_URL"]?
+  end
 end

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -27,14 +27,12 @@ module Mosquito
       end
     end
 
-    class_property connection_url : String? = ENV["REDIS_URL"]?
-
     def self.instance
       @@instance ||= new
     end
 
-    def initialize(url = nil)
-      url ||= @@connection_url
+    def initialize
+      url = Mosquito.settings.redis_url
       @connection = ::Redis.new(url: url)
     end
 

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -27,16 +27,15 @@ module Mosquito
       end
     end
 
+    class_property connection_url : String? = ENV["REDIS_URL"]?
+
     def self.instance
       @@instance ||= new
     end
 
-    def initialize
-      if url = ENV["REDIS_URL"]?
-        @connection = ::Redis.new(url: url)
-      else
-        @connection = ::Redis.new
-      end
+    def initialize(url = nil)
+      url ||= @@connection_url
+      @connection = ::Redis.new(url: url)
     end
 
     def self.key(*parts)


### PR DESCRIPTION
Idk how you feel about this. Personally I feel like, since so many things are being done at the class level rather than the instance level anyway (i.e. using `Class.instance` everywhere), it would make sense to have a `Config` module which holds configuration options. I'd be happy to add such a thing and update this PR, but for now I've just added a class property `connection_url` to the `Redis` class which defaults to `ENV["REDIS_URL"]`.

The benefit of this approach is that people can set their own environment variable if they want, or load the configuration option in another way. For example:

```crystal
# config.cr
require "mosquito"

Mosquito::Redis.connection_url = "redis://127.0.0.1:6379"

spawn do
  Mosquito::Runner.start
end
```

This would close #3 