### PR TITLE
Configure redis_url via configure block (Lucky/habitat integration)

### DIFF
--- a/demo/run.cr
+++ b/demo/run.cr
@@ -2,6 +2,10 @@ require "../src/mosquito"
 
 Log.builder.bind "*", :info, Log::IOBackend.new
 
+Mosquito.configure do |settings|
+  settings.redis_url = "redis://localhost:6379/3"
+end
+
 Mosquito::Redis.instance.flushall
 
 require "./jobs/*"

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: ~> 2.6.0
   habitat:
     github: luckyframework/habitat
-    version: ~> 0.4.3
+    version: ~> 0.4.4
 
 development_dependencies:
   minitest:

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,9 @@ dependencies:
   redis:
     github: stefanwille/crystal-redis
     version: ~> 2.6.0
+  habitat:
+    github: luckyframework/habitat
+    version: ~> 0.4.3
 
 development_dependencies:
   minitest:

--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -4,7 +4,63 @@ require "./external_classes"
 require "./mosquito/*"
 
 module Mosquito
+  # The previous redis connection initialization method would:
+  # - init with the env var if present
+  # - otherwise init without a connection string, which means a default connection to localhost:6379
+  #
+  # cf https://github.com/stefanwille/crystal-redis/blob/009e35fa40bbd518798afcc32c397402c6c6acb2/src/redis.cr#L95
+  #
+  # Unfortunately, even after you've taken the appropriate action, this message will still show up if the environment variable exists.
+  def Mosquito.default_redis_url
+    if ENV["REDIS_URL"]?
+      Log.warn {
+        <<-error_message
+        Configuring the Mosquito redis connection via environment variable is deprecated as of 2020-11.
+
+        The functionality will be removed in a minor version bump, 0.10.0.
+
+        The Redis url is now configured explicitly. To retain your current behavior, simply add this to your Mosquito runner before `Mosquito::Runner.start`:
+
+        Mosquito.configure do |settings|
+          settings.redis_url = ENV["REDIS_URL"]
+        end
+
+        See Also: https://github.com/robacarp/mosquito#connecting-to-redis
+
+        error_message
+      }
+    end
+
+    (ENV["REDIS_URL"]? || "redis://localhost:6379")
+  end
+
   Habitat.create do
-    setting redis_url : String? = ENV["REDIS_URL"]?
+    setting redis_url : String = Mosquito.default_redis_url
+  end
+
+  @@settings_validated = false
+
+  def self.validate_settings
+    return if @@settings_validated
+    @@settings_validated = true
+
+    if settings.redis_url?.nil?
+      message = <<-error
+      Mosquito cannot start because the redis connection string hasn't been provided.
+
+      For example, in your job runner:
+
+      Mosquito.configure do |settings|
+        settings.redis_url = "redis://localhost:6379"
+      end
+
+      See Also: https://github.com/robacarp/mosquito#connecting-to-redis
+      error
+
+      raise message
+    end
+
+    # just in case
+    Habitat.raise_if_missing_settings!
   end
 end

--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -1,5 +1,10 @@
+require "habitat"
+
 require "./external_classes"
 require "./mosquito/*"
 
 module Mosquito
+  Habitat.create do
+    setting redis_url : String? = ENV["REDIS_URL"]?
+  end
 end

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -27,14 +27,12 @@ module Mosquito
       end
     end
 
-    class_property connection_url : String? = ENV["REDIS_URL"]?
-
     def self.instance
       @@instance ||= new
     end
 
-    def initialize(url = nil)
-      url ||= @@connection_url
+    def initialize
+      url = Mosquito.settings.redis_url
       @connection = ::Redis.new(url: url)
     end
 

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -32,8 +32,9 @@ module Mosquito
     end
 
     def initialize
-      url = Mosquito.settings.redis_url
-      @connection = ::Redis.new(url: url)
+      Mosquito.validate_settings
+
+      @connection = ::Redis.new url: Mosquito.settings.redis_url
     end
 
     def self.key(*parts)

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -27,16 +27,15 @@ module Mosquito
       end
     end
 
+    class_property connection_url : String? = ENV["REDIS_URL"]?
+
     def self.instance
       @@instance ||= new
     end
 
-    def initialize
-      if url = ENV["REDIS_URL"]?
-        @connection = ::Redis.new(url: url)
-      else
-        @connection = ::Redis.new
-      end
+    def initialize(url = nil)
+      url ||= @@connection_url
+      @connection = ::Redis.new(url: url)
     end
 
     def self.key(*parts)

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -22,6 +22,7 @@ module Mosquito
     getter queues, start_time
 
     def initialize
+      Mosquito.validate_settings
       @queues = [] of Queue
       @start_time = 0_i64
       @execution_timestamps = {} of Symbol => Time

--- a/test/mosquito/configuration_test.cr
+++ b/test/mosquito/configuration_test.cr
@@ -1,0 +1,12 @@
+require "../test_helper"
+
+describe "Mosquito Config" do
+  it "allows setting / retrieving the redis url" do
+    Mosquito.temp_config(redis_url: "yolo") do
+      assert_equal "yolo", Mosquito.settings.redis_url
+    end
+  end
+
+  it "enforces missing settings are set" do
+  end
+end

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -4,9 +4,12 @@ require "minitest/focus"
 require "timecop"
 Timecop.safe_mode = true
 
-ENV["REDIS_URL"] = "redis://127.0.0.1:6379/3"
-
 require "../src/mosquito"
+
+Mosquito.configure do |settings|
+  settings.redis_url = "redis://localhost:6379/3"
+end
+
 require "./helpers/*"
 
 Mosquito::Redis.instance.flushall


### PR DESCRIPTION
Replaces #49 which has been abandoned.