### PR TITLE
use Time.measure instead of Benchmark.measure

### DIFF
--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -1,4 +1,3 @@
-require "benchmark"
 require "colorize"
 
 module Mosquito
@@ -130,18 +129,18 @@ module Mosquito
 
       Log.info { "#{"Running".colorize.magenta} task #{task} from #{q.name}" }
 
-      bench = Benchmark.measure do
+      bench = Time.measure do
         task.run
-      end
+      end.total_seconds
 
-      if bench.total > 0.1
-        time = "#{(bench.total).*(100).trunc./(100)}s".colorize.red
-      elsif bench.total > 0.001
-        time = "#{(bench.total * 1_000).trunc}ms".colorize.yellow
-      elsif bench.total > 0.000_001
-        time = "#{(bench.total * 100_000).trunc}µs".colorize.green
-      elsif bench.total > 0.000_000_001
-        time = "#{(bench.total * 1_000_000_000).trunc}ns".colorize.green
+      if bench > 0.1
+        time = "#{(bench).*(100).trunc./(100)}s".colorize.red
+      elsif bench > 0.001
+        time = "#{(bench * 1_000).trunc}ms".colorize.yellow
+      elsif bench > 0.000_001
+        time = "#{(bench * 100_000).trunc}µs".colorize.green
+      elsif bench > 0.000_000_001
+        time = "#{(bench * 1_000_000_000).trunc}ns".colorize.green
       else
         time = "no discernible time at all".colorize.green
       end

--- a/test/helpers/testable_runner.cr
+++ b/test/helpers/testable_runner.cr
@@ -17,6 +17,10 @@ class Mosquito::TestableRunner < Mosquito::Runner
     end
   end
 
+  def run(&block)
+    block.call
+  end
+
   def yield_once_a_second(&block)
     run_at_most every: 1.second, label: :testing do |t|
       yield

--- a/test/mosquito/runner/run_tasks_test.cr
+++ b/test/mosquito/runner/run_tasks_test.cr
@@ -123,5 +123,12 @@ describe "Mosquito::Runner#run_next_task" do
     end
   end
 
-
+  it "measures task time correctly" do
+    [ 0.05.seconds, 0.5.seconds, 1.second, 2.seconds ].each do |interval|
+      elapsed_time = Time.measure do
+        runner.run { sleep interval }
+      end
+      assert_in_delta(interval, elapsed_time.total_seconds, delta: 0.02)
+    end
+  end
 end


### PR DESCRIPTION
switch to `Time.measure` in place of `Benchmark.measure` for simplification and performance, as alternative to https://github.com/robacarp/mosquito/pull/56

`Benchmark.measure` appears to be slower, compared to `Time.measure`
```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("benchmark") {
    Benchmark.measure do
      Int64.new(2)
    end
  }
  x.report("time") {
    Time.measure do
      Int64.new(2)
    end
  }
end
```

```
benchmark 494.87k (  2.02µs) (± 5.95%)  64.0B/op  27.18× slower
     time  13.45M ( 74.34ns) (± 4.62%)   0.0B/op        fastest
```